### PR TITLE
Add podspec for cocoapods support in PMHTTP

### DIFF
--- a/PMHTTP.podspec
+++ b/PMHTTP.podspec
@@ -1,0 +1,29 @@
+Pod::Spec.new do |s|
+  s.name         = "PMHTTP"
+  s.version      = "0.9"
+  s.summary      = "Swift/Obj-C HTTP framework with a focus on REST and JSON"
+
+  s.description  = <<-DESC
+                   PMHTTP is an HTTP framework built around NSURLSession and designed for Swift while retaining Obj-C compatibility.
+                   DESC
+
+  s.homepage     = "https://github.com/postmates/PMHTTP"
+  s.license      = { :type => "MIT", :file => "LICENSE-MIT" }
+
+  s.author             = "Kevin Ballard"
+  s.social_media_url   = "https://twitter.com/eridius"
+
+  s.ios.deployment_target = "8.0"
+  s.osx.deployment_target = "10.10"
+  s.watchos.deployment_target = "2.0"
+  s.tvos.deployment_target = "9.0"
+
+  s.source       = { :git => "https://github.com/postmates/PMHTTP.git", :tag => "v#{s.version}" }
+  s.source_files  = "Sources"
+  s.private_header_files = "Sources/PMHTTPManager*.h"
+
+  s.framework  = "CFNetwork"
+  s.module_map = "Sources/module.modulemap"
+
+  s.dependency "PMJSON", "~> 0.9.0"
+end

--- a/README.md
+++ b/README.md
@@ -366,6 +366,13 @@ To install using [Carthage][], add the following to your Cartfile:
 github "postmates/PMHTTP" ~> 0.9
 ```
 
+### CocoaPods
+To install using [CocoaPods](https://cocoapods.org), add the following to your Podfile:
+
+```
+pod "PMHTTP", "~> 0.9"
+```
+
 Once installed, you can use this by adding `import PMHTTP` to your code.
 
 ## License


### PR DESCRIPTION
This addresses issue #9. Tested using `pod lib lint`, all platforms succeed.

Once merged the podspec will obviously need to be pushed to the cocoapods trunk and all that.

Hope this helps! Let me know if there's anything off that needs changing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/postmates/pmhttp/11)
<!-- Reviewable:end -->
