### PR TITLE
Fix HTTP Body Generation for JSON Requests

### DIFF
--- a/Sources/HTTPManager.swift
+++ b/Sources/HTTPManager.swift
@@ -1137,6 +1137,8 @@ extension HTTPManager {
             switch uploadBody {
             case .data(let data)?:
                 networkTask = inner.session.uploadTask(with: urlRequest, from: data)
+            case .json(let json)?:
+                networkTask = inner.session.uploadTask(with: urlRequest, from: JSON.encodeAsData(json, options: []))
             case _?:
                 networkTask = inner.session.uploadTask(withStreamedRequest: urlRequest)
             case nil:

--- a/Tests/PMHTTPTests.swift
+++ b/Tests/PMHTTPTests.swift
@@ -1596,7 +1596,7 @@ final class PMHTTPTests: PMHTTPTestCase {
                 completionHandler(HTTPServer.Response(status: .ok))
             }
             let request = HTTP.request(POST: "foo", contentType: "text/xml", data: bodyData)!
-            XCTAssertEqual(request.preparedURLRequest.httpBody, bodyData, "request body data")
+
             expectationForRequestSuccess(request) { (task, response, value) in
                 XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200, "status code")
             }
@@ -1634,7 +1634,7 @@ final class PMHTTPTests: PMHTTPTestCase {
         }
         let json: JSON = ["name": "stuff", "elts": [1,2,3], "ok": true, "error": nil]
         let request = HTTP.request(POST: "foo", json: json)!
-        XCTAssertEqual(request.preparedURLRequest.httpBody, JSON.encodeAsData(json), "request json data")
+
         expectationForRequestSuccess(request.parseAsJSON()) { task, response, json in
             XCTAssertEqual(response.mimeType, "application/json", "response MIME type")
             XCTAssertEqual(json, ["ok": true, "msg": "upload complete"], "response body json")


### PR DESCRIPTION
I ran into a tricky issue which I believe is a bug in PMHTTP, though I'm not entirely I'm using the API correctly.

When generating and performing a network request as following, the provided JSON is not transmitted as part of the HTTP body, instead the HTTP body is empty:

```swift
let request = HTTP.request(
    POST: "test",
    json: [
        "email" : user.email
    ]
)

request?.performRequest { task, result in
...
}
```

This can be fixed by extending the code that generates the upload body in `HTTPManager` to also check for a `.json` body type.

This code also seems to exist in the `preparedURLRequest` property (https://github.com/postmates/PMHTTP/blob/19e9c57c5618e9f7f5076f545418b6f5eebb7a1b/Sources/HTTPManagerRequest.swift#L483-L503), but that code isn't called form anywhere except from the test suite.

I would assume a long term fix would be to incorporate this code into the actual HTTP body generation.

The test suite itself did not expose this bug, since it was calling `preparedURLRequest`, which had the side effect of generating the HTTP body correctly. As soon as that line was removed from the tests, they failed expectedly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/postmates/pmhttp/16)
<!-- Reviewable:end -->
