### PR TITLE
% JSON and URL Encoded forms now have the body set

### DIFF
--- a/Sources/HTTPManager.swift
+++ b/Sources/HTTPManager.swift
@@ -1620,6 +1620,10 @@ extension HTTPManager {
             switch uploadBody {
             case .data(let data)?:
                 networkTask = inner.session.uploadTask(with: urlRequest, from: data)
+            case .formUrlEncoded(let queryItems)?:
+                networkTask = inner.session.uploadTask(with: urlRequest, from: FormURLEncoded.data(for: queryItems))
+            case .json(let json)?:
+                networkTask = inner.session.uploadTask(with: urlRequest, from: JSON.encodeAsData(json))
             case _?:
                 networkTask = inner.session.uploadTask(withStreamedRequest: urlRequest)
             case nil:


### PR DESCRIPTION
Some servers have problems if the Content-Length isn’t set. I don’t see a reason for the body to using streaming when it is a simple encoded form or JSON blob. If the Content-Length isn't set, the Transfer-Encoding is set as Chunked which causes some problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/postmates/pmhttp/26)
<!-- Reviewable:end -->
