### PR TITLE
Extend HTTPAuth to handle 403 Forbidden errors as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,10 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 ## Version History
 
+#### Development
+
+* Extend `HTTPAuth` to support handling 403 Forbidden errors as well.
+
 #### v3.0.4 (2017-09-05)
 
 * Support Swift 3.2.


### PR DESCRIPTION
`HTTPAuth` implementations can now optionally handle 403 Forbidden. This is intended for situations where you can't access a resource with your existing credentials but you can request new credentials that have greater access.

If the `HTTPAuth` implementation does not implement `handleForbidden` then no existing behavior is changed. Notably, the `retryBehavior` will still be invoked to handle 403 Forbidden responses.

Note: `HTTPRefreshableAuth` does not have any support for handling 403 Forbidden responses. Adding support in a generic fashion to that class is very complicated and most clients don't need this functionality.

Fixes #24.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/postmates/pmhttp/28)
<!-- Reviewable:end -->
