### PR TITLE
Escape semicolons in form-urlencoded

### DIFF
--- a/Sources/UploadSupport.swift
+++ b/Sources/UploadSupport.swift
@@ -67,14 +67,14 @@ internal enum UploadBody {
 private extension CharacterSet {
     static let urlQueryKeyAllowedCharacters: CharacterSet = {
         var cs = CharacterSet.urlQueryAllowed
-        cs.remove(charactersIn: "&=+")
+        cs.remove(charactersIn: "&=+;")
         cs.makeImmutable()
         return cs
     }()
     
     static let urlQueryValueAllowedCharacters: CharacterSet = {
         var cs = CharacterSet.urlQueryAllowed
-        cs.remove(charactersIn: "&+")
+        cs.remove(charactersIn: "&+;")
         cs.makeImmutable()
         return cs
     }()

--- a/Tests/PMHTTPTests.swift
+++ b/Tests/PMHTTPTests.swift
@@ -222,7 +222,7 @@ final class PMHTTPTests: PMHTTPTestCase {
     }
     
     func testParameters() {
-        let queryItems = [URLQueryItem(name: "foo", value: "bar"), URLQueryItem(name: "baz", value: "wat")]
+        let queryItems = [URLQueryItem(name: "foo", value: "bar"), URLQueryItem(name: "baz", value: "wat"), URLQueryItem(name: "special", value:"some;param;with;semicolons")]
         var parameters: [String: String] = [:]
         for item in queryItems {
             parameters[item.name] = item.value
@@ -284,6 +284,8 @@ final class PMHTTPTests: PMHTTPTestCase {
                     XCTFail("Missing request body, or body not utf-8 (\(method))")
                     return completionHandler(HTTPServer.Response(status: .badRequest))
                 }
+                // some servers treat an un-percent-ecoded semicolon as a separator
+                XCTAssertFalse(bodyText.contains(";"), "Body text shouldn't contain semicolons")
                 var comps = URLComponents()
                 comps.percentEncodedQuery = bodyText
                 // sort the query items because the dictionary form is not order-preserving


### PR DESCRIPTION
Some servers treat an un-percent-ecoded semicolon as a separator

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/postmates/pmhttp/38)
<!-- Reviewable:end -->
