### PR TITLE
Import UIKit in umbrella header to fix Xcode 12.5 build error

### DIFF
--- a/Sources/PMHTTP.h
+++ b/Sources/PMHTTP.h
@@ -14,6 +14,10 @@
 
 #import <Foundation/Foundation.h>
 
+#if TARGET_OS_IPHONE
+#import <CoreGraphics/CoreGraphics.h>
+#endif
+
 //! Project version number for PMHTTP.
 FOUNDATION_EXPORT double PMHTTPVersionNumber;
 


### PR DESCRIPTION
<img width="816" alt="image" src="https://user-images.githubusercontent.com/666807/115292733-34f33b80-a10b-11eb-8cc3-86c2f8bb08ad.png">